### PR TITLE
Avoid errors with python 3 by using python 2 explicitly

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -29,7 +29,10 @@
     ;; Beautify json with support for non-ascii characters.
     ;; Thanks to https://github.com/jarl-dk for this improvement.
     (shell-command-on-region b e
-     "python2 -c 'import sys,json; data=json.loads(sys.stdin.read()); print json.dumps(data,sort_keys=True,indent=4).decode(\"unicode_escape\").encode(\"utf8\",\"replace\")'" (current-buffer) t)))
+	(concat (if (executable-find "env") "env " "")
+		(concat (if (executable-find "python2") "python2" "python")
+			" -c 'import sys,json; data=json.loads(sys.stdin.read()); print json.dumps(data,sort_keys=True,indent=4).decode(\"unicode_escape\").encode(\"utf8\",\"replace\")'"))
+	(current-buffer) t)))
 
 ;;;###autoload
 (define-derived-mode json-mode javascript-mode "JSON"


### PR DESCRIPTION
Just as the title states. Many linux OSes are starting to refer to python 3 via 'python,' so this change is needed to maintain functionality.

It would be even better if it used "env python2," but that's more than what is _needed_, which is this patch.

Thanks for putting this together. It really works great.
