### PR TITLE
Remove trailing blank space when beautify-json

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -31,7 +31,7 @@
     (shell-command-on-region b e
                              (concat (if (executable-find "env") "env " "")
                                      (concat (if (executable-find "python2") "python2" "python")
-                                             " -c 'import sys,json; data=json.loads(sys.stdin.read()); print json.dumps(data,sort_keys=True,indent=4).decode(\"unicode_escape\").encode(\"utf8\",\"replace\")'"))
+                                             " -c 'import sys,json; data=json.loads(sys.stdin.read()); print json.dumps(data,sort_keys=True,indent=4,separators=(\",\", \": \")).decode(\"unicode_escape\").encode(\"utf8\",\"replace\")'"))
                              (current-buffer) t)))
 
 ;;;###autoload


### PR DESCRIPTION
before

<pre>
{
    "foo": "bar", 
    "hoge": "piyo"
}
</pre>


after

<pre>
{
    "foo": "bar",
    "hoge": "piyo"
}
</pre>


It's the same at first glance, but differences in  after the comma.

I think this JSON is more beautiful than the old one. What do you think?
