### PR TITLE
Make compatible with Emacs 23

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -79,10 +79,12 @@
       ;; delete the window if we have one,
       ;; so we can recreate it in the correct position
       (if temp-window
-          (delete-window temp-window))
+	  (delete-window temp-window))
 
       ;; always put the temp window below the json window
-      (set-window-buffer (split-window-below) temp-name))
+      (set-window-buffer (if (fboundp 'split-window-below)
+			     (split-window-below)
+			   (split-window-vertically)) temp-name))
     ))
 
 (define-key json-mode-map (kbd "C-c C-p") 'json-mode-show-path)


### PR DESCRIPTION
Makes this mode compatible with Emacs 23 by using `split-window-vertically` instead of `split-window-below`.