### PR TITLE
Add some common files to auto-load-alist

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -69,6 +69,12 @@
 (add-to-list 'auto-mode-alist '("\\.json$" . json-mode))
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jsonld$" . json-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist (cons (rx (or
+                                         ".babelrc"
+                                         ".bowerrc"
+                                         ) eos)
+                                    'json-mode))
 
 ;;;###autoload
 (defun json-mode-show-path ()


### PR DESCRIPTION
It would be nice if some of these commonly used files were recognized by default as `json-mode` files.

If people find more they can stick them to the list.

Right now I use 

```elisp
(use-package json-mode
  :mode (rx (or ".babelrc" ".bowerrc") eos))
```

but I figured this is general enough to be included in the package itself.