### PR TITLE
Refactor to allow setting custom autoload entry

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -90,12 +90,12 @@
       ;; delete the window if we have one,
       ;; so we can recreate it in the correct position
       (if temp-window
-	  (delete-window temp-window))
+          (delete-window temp-window))
 
       ;; always put the temp window below the json window
       (set-window-buffer (if (fboundp 'split-window-below)
-			     (split-window-below)
-			   (split-window-vertically)) temp-name))
+                             (split-window-below)
+                           (split-window-vertically)) temp-name))
     ))
 
 (define-key json-mode-map (kbd "C-c C-p") 'json-mode-show-path)

--- a/json-mode.el
+++ b/json-mode.el
@@ -57,7 +57,7 @@ Return the new `auto-mode-alist' entry"
          (old-entry (when (boundp 'json-mode--auto-mode-entry)
                       json-mode--auto-mode-entry)))
     (setq auto-mode-alist (delete old-entry auto-mode-alist))
-    (add-to-list 'auto-mode-alist new-entry 'json-mode)
+    (add-to-list 'auto-mode-alist new-entry)
     new-entry))
 
 ;;;###autoload

--- a/json-mode.el
+++ b/json-mode.el
@@ -116,6 +116,9 @@ This function calls `json-mode--update-auto-mode' to change the
   "Major mode for editing JSON files"
   (set (make-local-variable 'font-lock-defaults) '(json-font-lock-keywords-1 t)))
 
+;; Well formatted JSON files almost always begin with “{” or “[”.
+(add-to-list 'magic-mode-alist '("^[{[]$" . json-mode))
+
 ;;;###autoload
 (defun json-mode-show-path ()
   (interactive)

--- a/json-mode.el
+++ b/json-mode.el
@@ -1,4 +1,4 @@
-;;; json-mode.el --- Major mode for editing JSON files
+;;; json-mode.el --- Major mode for editing JSON files.
 
 ;; Copyright (C) 2011-2014 Josh Johnston
 
@@ -30,6 +30,10 @@
 (require 'rx)
 (require 'json-snatcher)
 (require 'json-reformat)
+
+(defgroup json-mode '()
+  "Major mode for editing JSON files."
+  :group 'js)
 
 (defconst json-mode-quoted-string-re
   (rx (group (char ?\")


### PR DESCRIPTION
This allows setting custom files to be loaded automatically with `json-mode`. I saw that some files were added recently, but it doesn't cover much of the file names we can get in web development.

Unless the customization option is set from `custom-set-variables`, the package is not loaded until an `autoload` function is called.