### PR TITLE
Editing shortcuts and keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ json-mode.el
 
 Major mode for editing JSON files.
 
-Extends the builtin js-mode to add better syntax highlighting for JSON.
+Extends the builtin js-mode to add better syntax highlighting for JSON
+and some nice editing keybindings.
 
 Install
 ----
@@ -19,6 +20,10 @@ Default Keybindings
 
 - `C-c C-f`: format the region/buffer with `json-reformat` (<https://github.com/gongo/json-reformat>)
 - `C-c C-p`: display a path to the object at point with `json-snatcher` (<https://github.com/Sterlingg/json-snatcher>)
+- `C-c C-t`: Toggle between `true` and `false` at point
+- `C-c C-k`: Replace the sexp at point with `null`
+- `C-c C-i`: Increment the number at point
+- `C-c C-d`: Decrement the number at point
 
 Indent Width
 ----

--- a/json-mode.el
+++ b/json-mode.el
@@ -155,6 +155,72 @@ This function calls `json-mode--update-auto-mode' to change the
 
 (define-key json-mode-map (kbd "C-c C-f") 'json-mode-beautify)
 
+(defun json-toggle-boolean ()
+  "If point is on `true' or `false', toggle it."
+  (interactive)
+  (unless (nth 8 (syntax-ppss)) ; inside a keyword, string or comment
+    (let* ((bounds (bounds-of-thing-at-point 'symbol))
+           (string (and bounds (buffer-substring-no-properties (car bounds) (cdr bounds))))
+           (pt (point)))
+      (when (and bounds (member string '("true" "false")))
+        (delete-region (car bounds) (cdr bounds))
+        (cond
+         ((string= "true" string)
+          (insert "false")
+          (goto-char (if (= pt (cdr bounds)) (1+ pt) pt)))
+         (t
+          (insert "true")
+          (goto-char (if (= pt (cdr bounds)) (1- pt) pt))))))))
+
+(define-key json-mode-map (kbd "C-c C-t") 'json-toggle-boolean)
+
+(defun json-nullify-sexp ()
+  "Replace the sexp at point with `null'."
+  (interactive)
+  (let ((syntax (syntax-ppss)) symbol)
+    (cond
+     ((nth 4 syntax) nil)               ; inside a comment
+     ((nth 3 syntax)                    ; inside a string
+      (goto-char (nth 8 syntax))
+      (when (save-excursion (forward-sexp) (skip-chars-forward "[:space:]") (eq (char-after) ?:))
+        ;; sexp is an object key, so we nullify the entire object
+        (goto-char (nth 1 syntax)))
+      (kill-sexp)
+      (insert "null"))
+     ((setq symbol (bounds-of-thing-at-point 'symbol))
+      (cond
+       ((looking-at-p "null"))
+       ((save-excursion (skip-chars-backward "[0-9.]") (looking-at json-mode-number-re))
+        (kill-region (match-beginning 0) (match-end 0))
+        (insert "null"))
+       (t (kill-region (car symbol) (cdr symbol)) (insert "null"))))
+     ((< 0 (nth 0 syntax))
+      (goto-char (nth 1 syntax))
+      (kill-sexp)
+      (insert "null"))
+     (t nil))))
+
+(define-key json-mode-map (kbd "C-c C-k") 'json-nullify-sexp)
+
+(defun json-increment-number-at-point (&optional delta)
+  "Add DELTA to the number at point; DELTA defaults to 1."
+  (interactive)
+  (when (save-excursion (skip-chars-backward "[0-9.]") (looking-at json-mode-number-re))
+    (let ((num (+ (or delta 1)
+                  (string-to-number (buffer-substring-no-properties (match-beginning 0) (match-end 0)))))
+          (pt (point)))
+      (delete-region (match-beginning 0) (match-end 0))
+      (insert (number-to-string num))
+      (goto-char pt))))
+
+(define-key json-mode-map (kbd "C-c C-i") 'json-increment-number-at-point)
+
+(defun json-decrement-number-at-point ()
+  "Decrement the number at point."
+  (interactive)
+  (json-increment-number-at-point -1))
+
+(define-key json-mode-map (kbd "C-c C-d") 'json-decrement-number-at-point)
 
 (provide 'json-mode)
 ;;; json-mode.el ends here


### PR DESCRIPTION
This PR adds a few keybindings that automate some common JSON edition operations:

- `C-c C-t`: Toggle between `true` and `false` at point
  1. **before**: `"options": {"alwaysInclude": |true, ...}`
    **after**: `"options": {"alwaysInclude": |false, ...}`
  2. **before**: `"options": {"alwaysInclude": |false, ...}`
    **after**: `"options": {"alwaysInclude": |true, ...}`

- `C-c C-k`: Replace the sexp at point with `null`
  1. **before**: `"options": {|"alwaysInclude": true, ...}`
    **after**: `"options": null|`
  2. **before**: `"question": {"number": |5, "type": "number"},`
    **after**: `"question": {"number": null|, "type": "number"},`
  3. **before**: `"question": {"number": 5, "type": "nu|mber"},`
    **after**: `"question": {"number": null, "type": null|},`

- `C-c C-i`: Increment the number at point
  **before**: `"question": {"number": |5, "type": "number"},`
  **after**: `"question": {"number": |6, "type": "number"},`

- `C-c C-d`: Decrement the number at point
  **before**: `"question": {"number": |5, "type": "number"},`
  **after**: `"question": {"number": |4, "type": "number"},`