### PR TITLE
Use magic-fallback-mode-alist instead of magic-mode-alist

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -121,7 +121,8 @@ This function calls `json-mode--update-auto-mode' to change the
   (set (make-local-variable 'font-lock-defaults) '(json-font-lock-keywords-1 t)))
 
 ;; Well formatted JSON files almost always begin with “{” or “[”.
-(add-to-list 'magic-mode-alist '("^[{[]$" . json-mode))
+;;;###autoload
+(add-to-list 'magic-fallback-mode-alist '("^[{[]$" . json-mode))
 
 ;;;###autoload
 (defun json-mode-show-path ()


### PR DESCRIPTION
Currently json-mode uses `magic-mode-alist` for mode detection. This list is prioritized over `auto-mode-alist` so it causes problems when a file starts with a either `{` or `[` but isn't actually JSON.

Emacs provides `magic-fallback-mode-alist` which is essentially the same thing as `magic-mode-alist`, but is checked after `auto-mode-alist`. In a fresh install of emacs, it's used for detecting things like html/xml, so this seems like it would be a better fit for json-mode.

See [Choosing Modes](https://www.gnu.org/software/emacs/manual/html_node/emacs/Choosing-Modes.html#Choosing-Modes) in the emacs manual for more details.