### PR TITLE
Fix docstrings according to checkdoc

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -66,8 +66,7 @@ Return the new `auto-mode-alist' entry"
                                       ".bowerrc"
                                       "composer.lock"
                                       )
-  "List of filename as string to pass for the JSON entry of
-`auto-mode-alist'.
+  "List of filenames as for the JSON entry of `auto-mode-alist'.
 
 Note however that custom `json-mode' entries in `auto-mode-alist'
 won’t be affected."
@@ -126,7 +125,7 @@ This function calls `json-mode--update-auto-mode' to change the
 
 ;;;###autoload
 (defun json-mode-show-path ()
-  "Print the path to the node at point to the minibuffer, and yank to the kill ring."
+  "Print the path to the node at point to the minibuffer."
   (interactive)
   (message (jsons-print-path)))
 
@@ -134,6 +133,7 @@ This function calls `json-mode--update-auto-mode' to change the
 
 ;;;###autoload
 (defun json-mode-kill-path ()
+  "Save JSON path to object at point to kill ring."
   (interactive)
     (kill-new (jsons-print-path)))
 


### PR DESCRIPTION
I've found some problems with docstrings in this code, so I ran checkdoc and fixed all issues it found. I also updated the docstring for `json-mode-show-path`, as it was misleading.